### PR TITLE
added configurations to global properties about tiff

### DIFF
--- a/src/main/amp/config/alfresco/subsystems/Transformers/default/remote-jod-transformers.properties
+++ b/src/main/amp/config/alfresco/subsystems/Transformers/default/remote-jod-transformers.properties
@@ -44,15 +44,13 @@ content.transformer.RemoteJODConverter.extensions.odt.pdf.supported=true
 content.transformer.RemoteJODConverter.extensions.odp.pdf.supported=true
 content.transformer.RemoteJODConverter.extensions.ods.pdf.supported=true
 content.transformer.RemoteJODConverter.extensions.odf.pdf.supported=true
+content.transformer.RemoteJODConverter.extensions.tiff.pdf.supported=true
 
 content.transformer.complex.RemoteJODConverter.Html2Pdf.pipeline=RemoteJODConverter|odt|RemoteJODConverter
 content.transformer.complex.RemoteJODConverter.Html2Pdf.extensions.html.pdf.supported=true
 content.transformer.complex.RemoteJODConverter.Html2Pdf.extensions.html.pdf.priority=50
 
 
-content.transformer.RemoteJODConverter.extensions.tiff.pdf.priority=30
-content.transformer.RemoteJODConverter.extensions.tiff.pdf.supported=true
-content.transformer.RemoteJODConverter.extensions.tiff.pdf.maxSourceSizeKBytes=100000
 
 content.transformer.complex.RemoteJODConverter.2Pdf.available=false
 content.transformer.complex.RemoteJODConverter.2Pdf.failover=RemoteJODConverter|complex.RemoteJODConverter.Html2Pdf
@@ -87,3 +85,4 @@ content.transformer.complex.RemoteJODConverter.PdfBox.extensions.doc.txt.support
 content.transformer.complex.RemoteJODConverter.PdfBox.extensions.ppsx.txt.supported=false
 content.transformer.complex.RemoteJODConverter.PdfBox.extensions.xlsb.txt.maxSourceSizeKBytes=1024
 content.transformer.complex.RemoteJODConverter.PdfBox.extensions.potm.txt.maxSourceSizeKBytes=1024
+content.transformer.RemoteJODConverter.extensions.tiff.pdf.maxSourceSizeKBytes=100000

--- a/src/main/amp/config/alfresco/subsystems/Transformers/default/remote-jod-transformers.properties
+++ b/src/main/amp/config/alfresco/subsystems/Transformers/default/remote-jod-transformers.properties
@@ -12,6 +12,7 @@ content.transformer.RemoteJODConverter.extensions.ppt.pdf.maxSourceSizeKBytes=61
 content.transformer.RemoteJODConverter.extensions.txt.pdf.maxSourceSizeKBytes=5120
 content.transformer.RemoteJODConverter.extensions.rtf.pdf.maxSourceSizeKBytes=5120
 content.transformer.RemoteJODConverter.extensions.doc.pdf.maxSourceSizeKBytes=10240
+content.transformer.RemoteJODConverter.extensions.tiff.pdf.maxSourceSizeKBytes=10240
 
 content.transformer.RemoteJODConverter.extensions.xlsm.pdf.supported=true
 content.transformer.RemoteJODConverter.extensions.pptm.pdf.supported=true
@@ -85,4 +86,4 @@ content.transformer.complex.RemoteJODConverter.PdfBox.extensions.doc.txt.support
 content.transformer.complex.RemoteJODConverter.PdfBox.extensions.ppsx.txt.supported=false
 content.transformer.complex.RemoteJODConverter.PdfBox.extensions.xlsb.txt.maxSourceSizeKBytes=1024
 content.transformer.complex.RemoteJODConverter.PdfBox.extensions.potm.txt.maxSourceSizeKBytes=1024
-content.transformer.RemoteJODConverter.extensions.tiff.pdf.maxSourceSizeKBytes=100000
+

--- a/src/main/amp/config/alfresco/subsystems/Transformers/default/remote-jod-transformers.properties
+++ b/src/main/amp/config/alfresco/subsystems/Transformers/default/remote-jod-transformers.properties
@@ -49,6 +49,11 @@ content.transformer.complex.RemoteJODConverter.Html2Pdf.pipeline=RemoteJODConver
 content.transformer.complex.RemoteJODConverter.Html2Pdf.extensions.html.pdf.supported=true
 content.transformer.complex.RemoteJODConverter.Html2Pdf.extensions.html.pdf.priority=50
 
+
+content.transformer.RemoteJODConverter.extensions.tiff.pdf.priority=30
+content.transformer.RemoteJODConverter.extensions.tiff.pdf.supported=true
+content.transformer.RemoteJODConverter.extensions.tiff.pdf.maxSourceSizeKBytes=100000
+
 content.transformer.complex.RemoteJODConverter.2Pdf.available=false
 content.transformer.complex.RemoteJODConverter.2Pdf.failover=RemoteJODConverter|complex.RemoteJODConverter.Html2Pdf
 content.transformer.complex.RemoteJODConverter.2Pdf.priority=150


### PR DESCRIPTION
Added the tiff configurations to the remote-jod-converter-properties under the amp to make conversion from tiff to pdf enabled by default when using the alfresco-remote-jodconverter.

Converting tiff to pdf is already supported in jodconverter itself.